### PR TITLE
Add a "super-greedy" mode for vector arguments

### DIFF
--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -284,7 +284,10 @@ A few things to keep in mind about positional arguments:
 - If the unlimited one is required it will prevent any optional positionals
   from getting populated, since it eats up all the arguments before they get
   a turn.
-
+- A positional with nargs set to `Dim::superGreedyMode` becomes very greedy
+  and eats up everything, including arguments with '-' and '--'. This can be
+  useful if you want to pass rest of your command line to another program
+  with its own options.
 
 ## Flag Options
 Many options are flags with no associated value, they just set an option

--- a/libs/dimcli/cli.h
+++ b/libs/dimcli/cli.h
@@ -174,6 +174,7 @@ enum {
     kExitSoftware = 70, // EX_SOFTWARE  - internal software error
 };
 
+const int superGreedyMode = -2;
 
 /****************************************************************************
 *
@@ -1823,8 +1824,8 @@ Cli::OptVec<T>::OptVec(
     : OptShim<OptVec, T>{keys, std::is_same<T, bool>::value}
     , m_proxy(values)
 {
-    assert(nargs >= -1
-        && "max values in a vector option must be >= 0, or -1 (unlimited)");
+    assert(nargs >= -2
+        && "max values in a vector option must be >= 0, -1 (unlimited), or Cli::superGreedyMode");
     this->m_vector = true;
     this->m_nargs = nargs;
 }
@@ -1866,7 +1867,7 @@ inline bool Cli::OptVec<T>::defaultValueToString(std::string & out) const {
 //===========================================================================
 template <typename T>
 inline bool Cli::OptVec<T>::assign(const std::string & name, size_t pos) {
-    if (this->m_nargs != -1
+    if (this->m_nargs >= 0
         && (size_t) this->m_nargs == m_proxy->m_matches.size()
     ) {
         return false;


### PR DESCRIPTION
When such positional vector argument is encountered, it sets the switch
which is otherwise is set by the lone "--" argument. Thus such a vector
can hold the whole command line for another command allowing tp
implement something like the sudo command.